### PR TITLE
Refactor gallery picker to use activity result API

### DIFF
--- a/app/src/main/java/com/ugrcaan/qriosity/MainActivity.kt
+++ b/app/src/main/java/com/ugrcaan/qriosity/MainActivity.kt
@@ -127,6 +127,10 @@ class MainActivity : AppCompatActivity() {
             return
         }
 
+        processImageForQrCode(bitmap)
+    }
+
+    private fun processImageForQrCode(bitmap: Bitmap) {
         // Convert bitmap to byte array
         val byteArrayOutputStream = ByteArrayOutputStream()
         bitmap.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)


### PR DESCRIPTION
## Summary
- replace the legacy gallery picker intent with an ActivityResultLauncher using ActivityResultContracts.GetContent
- update QR image processing to accept URIs returned by the new gallery picker

## Testing
- `./gradlew lint` *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4a42be608328a87942c8049b96fd